### PR TITLE
修复glide使用问题

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -1,4 +1,4 @@
-package: falcon-log-agent
+package: github.com/didi/falcon-log-agent
 import:
 - package: github.com/gin-gonic/gin
   version: ~1.2.0


### PR DESCRIPTION
package字段如果不是完整网络路径，在执行glide up/install 等命令时无法识别哪些是自依赖，哪些是应该放到vendor下的第三方依赖